### PR TITLE
Update to specify adapter on wifi connect.

### DIFF
--- a/payloads/extensions/wifi_connect.sh
+++ b/payloads/extensions/wifi_connect.sh
@@ -5,10 +5,11 @@
 # Author: Hak5Darren
 
 function WIFI_CONNECT() {
-    ifconfig wlan0 up;sleep 10
-    echo -e "network={\nssid=\"$WIFI_SSID\"\npsk=\"$WIFI_PASS\"\npriority=1\n}">/tmp/wpa.conf
-    wpa_supplicant -B -Dnl80211 -i wlan0 -c /tmp/wpa.conf
-    while(iwconfig wlan0 | grep Not-Associated); do sleep 1; done
-    udhcpc -i wlan0
+    if [ "$WIFI_INT" == "" ]; then WIFI_INT=wlan0; fi
+    ifconfig $WIFI_INT up;sleep 10
+    echo -e "network={\nssid=\"$WIFI_SSID\"\npsk=\"$WIFI_PASS\"\npriority=1\n}">/tmp/wpa-$WIFI_INT.conf
+    wpa_supplicant -B -Dnl80211 -i $WIFI_INT -c /tmp/wpa-$WIFI_INT.conf
+    while(iwconfig $WIFI_INT | grep Not-Associated); do sleep 1; done
+    udhcpc -i $WIFI_INT
 }
 export -f WIFI_CONNECT

--- a/payloads/extensions/wifi_connect.sh
+++ b/payloads/extensions/wifi_connect.sh
@@ -5,7 +5,7 @@
 # Author: Hak5Darren
 
 function WIFI_CONNECT() {
-    if [ "$WIFI_INT" == "" ]; then WIFI_INT=wlan0; fi
+    [[ "x$WIFI_INT" == "x" ]] && WIFI_INT=wlan0
     ifconfig $WIFI_INT up;sleep 10
     echo -e "network={\nssid=\"$WIFI_SSID\"\npsk=\"$WIFI_PASS\"\npriority=1\n}">/tmp/wpa-$WIFI_INT.conf
     wpa_supplicant -B -Dnl80211 -i $WIFI_INT -c /tmp/wpa-$WIFI_INT.conf


### PR DESCRIPTION
Updated the wifi connect function to allow the selection of a wifi interface. It will default to wlan0 if the new variable WIFI_INT is not set.

The update is so I can run an external adapter, acting as an access point for another device, like the screen crab, then forward to the traffic to the local wifi.